### PR TITLE
Support passing pre-created RabbitMQ instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ktor-rabbitmq
 [![](https://jitpack.io/v/JUtupe/ktor-rabbitmq.svg)](https://jitpack.io/#JUtupe/ktor-rabbitmq)
 
-Ktor RabbitMQ feature
+## Installing Ktor RabbitMQ feature
 
 `implementation "com.github.JUtupe:ktor-rabbitmq:$ktor_rabbitmq_feature"`
 
@@ -50,5 +50,29 @@ rabbitConsumer {
         // We can omit 'this' part
         this.ack(multiple = false)
     }
+}
+```
+
+## Passing pre-initialized RabbitMQ instance
+
+In case you need to initialize RabbitMQ prior to starting it (e. g. to kickstart your DI injection), you
+can pass pre-created RabbitMQ instance to the plugin:
+
+```kotlin
+install(RabbitMQ) {
+    rabbitMQInstance = RabbitMQInstance(RabbitMQConfiguration.create()
+        .apply {
+            uri = "amqp://guest:guest@${rabbit.host}:${rabbit.amqpPort}"
+            connectionName = "Connection name"
+
+            serialize { jacksonObjectMapper().writeValueAsBytes(it) }
+            deserialize { bytes, type -> jacksonObjectMapper().readValue(bytes, type.javaObjectType) }
+
+            initialize {
+                exchangeDeclare("exchange", "direct", true)
+                queueDeclare("queue", true, false, false, emptyMap())
+                queueBind("queue", "exchange", "routingKey")
+            }
+        })
 }
 ```

--- a/src/main/kotlin/pl/jutupe/ktor_rabbitmq/RabbitConsumer.kt
+++ b/src/main/kotlin/pl/jutupe/ktor_rabbitmq/RabbitConsumer.kt
@@ -6,11 +6,11 @@ import io.ktor.application.feature
 import io.ktor.util.pipeline.ContextDsl
 
 @ContextDsl
-fun Application.rabbitConsumer(configuration: RabbitMQ.() -> Unit): RabbitMQ =
+fun Application.rabbitConsumer(configuration: RabbitMQInstance.() -> Unit): RabbitMQInstance =
     feature(RabbitMQ).apply(configuration)
 
 @ContextDsl
-inline fun <reified T> RabbitMQ.consume(
+inline fun <reified T> RabbitMQInstance.consume(
     queue: String,
     autoAck: Boolean = true,
     basicQos: Int? = null,

--- a/src/main/kotlin/pl/jutupe/ktor_rabbitmq/RabbitMQ.kt
+++ b/src/main/kotlin/pl/jutupe/ktor_rabbitmq/RabbitMQ.kt
@@ -1,57 +1,27 @@
 package pl.jutupe.ktor_rabbitmq
 
-import com.rabbitmq.client.Channel
-import com.rabbitmq.client.Connection
-import com.rabbitmq.client.ConnectionFactory
 import io.ktor.application.Application
 import io.ktor.application.ApplicationFeature
 import io.ktor.util.AttributeKey
-import org.slf4j.Logger
 
-class RabbitMQ(
-    val configuration: RabbitMQConfiguration
-) {
+class RabbitMQ {
 
-    val logger: Logger? = configuration.logger
+    companion object Feature : ApplicationFeature<Application, RabbitMQConfiguration, RabbitMQInstance> {
 
-    private val connectionFactory =
-        ConnectionFactory().apply {
-            setUri(configuration.uri)
-        }
-    private val connection: Connection = connectionFactory.newConnection(configuration.connectionName)
-    private val channel: Channel = connection.createChannel()
+        val RabbitMQKey = AttributeKey<RabbitMQInstance>("RabbitMQ")
 
-    private fun initialize() {
-        configuration.initializeBlock.invoke(channel)
-    }
-
-    fun withChannel(block: Channel.() -> Unit) {
-        block.invoke(channel)
-    }
-
-    inline fun <reified T> deserialize(bytes: ByteArray): T =
-        configuration.deserializeBlock.invoke(bytes, T::class) as T
-
-    fun <T> serialize(body: T): ByteArray =
-        configuration.serializeBlock.invoke(body!!)
-
-    companion object Feature : ApplicationFeature<Application, RabbitMQConfiguration, RabbitMQ> {
-
-        val RabbitMQKey = AttributeKey<RabbitMQ>("RabbitMQ")
-
-        override val key: AttributeKey<RabbitMQ>
+        override val key: AttributeKey<RabbitMQInstance>
             get() = RabbitMQKey
 
         override fun install(
             pipeline: Application,
             configure: RabbitMQConfiguration.() -> Unit
-        ): RabbitMQ {
+        ): RabbitMQInstance {
             val configuration = RabbitMQConfiguration.create()
             configuration.apply(configure)
 
-            val rabbit = RabbitMQ(configuration).apply {
-                initialize()
-            }
+            val rabbit = configuration.rabbitMQInstance ?: RabbitMQInstance(configuration)
+            rabbit.apply { initialize() }
 
             pipeline.attributes.put(key, rabbit)
 

--- a/src/main/kotlin/pl/jutupe/ktor_rabbitmq/RabbitMQConfiguration.kt
+++ b/src/main/kotlin/pl/jutupe/ktor_rabbitmq/RabbitMQConfiguration.kt
@@ -9,6 +9,7 @@ import kotlin.reflect.KClass
 class RabbitMQConfiguration private constructor() {
 
     lateinit var uri: String
+    var rabbitMQInstance: RabbitMQInstance? = null
     var connectionName: String? = null
     var logger: Logger? = null
         private set

--- a/src/main/kotlin/pl/jutupe/ktor_rabbitmq/RabbitMQInstance.kt
+++ b/src/main/kotlin/pl/jutupe/ktor_rabbitmq/RabbitMQInstance.kt
@@ -31,5 +31,4 @@ class RabbitMQInstance(
 
     fun <T> serialize(body: T): ByteArray =
         configuration.serializeBlock.invoke(body!!)
-
 }

--- a/src/main/kotlin/pl/jutupe/ktor_rabbitmq/RabbitMQInstance.kt
+++ b/src/main/kotlin/pl/jutupe/ktor_rabbitmq/RabbitMQInstance.kt
@@ -1,0 +1,35 @@
+package pl.jutupe.ktor_rabbitmq
+
+import com.rabbitmq.client.Channel
+import com.rabbitmq.client.Connection
+import com.rabbitmq.client.ConnectionFactory
+import org.slf4j.Logger
+
+class RabbitMQInstance(
+    val configuration: RabbitMQConfiguration
+) {
+
+    val logger: Logger? = configuration.logger
+
+    private val connectionFactory =
+        ConnectionFactory().apply {
+            setUri(configuration.uri)
+        }
+    private val connection: Connection = connectionFactory.newConnection(configuration.connectionName)
+    private val channel: Channel = connection.createChannel()
+
+    fun initialize() {
+        configuration.initializeBlock.invoke(channel)
+    }
+
+    fun withChannel(block: Channel.() -> Unit) {
+        block.invoke(channel)
+    }
+
+    inline fun <reified T> deserialize(bytes: ByteArray): T =
+        configuration.deserializeBlock.invoke(bytes, T::class) as T
+
+    fun <T> serialize(body: T): ByteArray =
+        configuration.serializeBlock.invoke(body!!)
+
+}

--- a/src/main/kotlin/pl/jutupe/ktor_rabbitmq/RabbitPublisher.kt
+++ b/src/main/kotlin/pl/jutupe/ktor_rabbitmq/RabbitPublisher.kt
@@ -7,7 +7,7 @@ fun <T> ApplicationCall.publish(exchange: String, routingKey: String, props: AMQ
     application.attributes[RabbitMQ.RabbitMQKey].publish(exchange, routingKey, props, body)
 }
 
-fun <T> RabbitMQ.publish(exchange: String, routingKey: String, props: AMQP.BasicProperties?, body: T) {
+fun <T> RabbitMQInstance.publish(exchange: String, routingKey: String, props: AMQP.BasicProperties?, body: T) {
     withChannel {
         val bytes = serialize(body)
 

--- a/src/test/kotlin/pl/jutupe/ktor_rabbitmq/ConsumerTest.kt
+++ b/src/test/kotlin/pl/jutupe/ktor_rabbitmq/ConsumerTest.kt
@@ -59,20 +59,22 @@ class ConsumerTest : IntegrationTest() {
 
         withTestApplication({
             install(RabbitMQ) {
-                rabbitMQInstance = RabbitMQInstance(RabbitMQConfiguration.create()
-                    .apply {
-                        uri = "amqp://guest:guest@${rabbit.host}:${rabbit.amqpPort}"
-                        connectionName = "Connection name"
+                rabbitMQInstance = RabbitMQInstance(
+                    RabbitMQConfiguration.create()
+                        .apply {
+                            uri = "amqp://guest:guest@${rabbit.host}:${rabbit.amqpPort}"
+                            connectionName = "Connection name"
 
-                        serialize { jacksonObjectMapper().writeValueAsBytes(it) }
-                        deserialize { bytes, type -> jacksonObjectMapper().readValue(bytes, type.javaObjectType) }
+                            serialize { jacksonObjectMapper().writeValueAsBytes(it) }
+                            deserialize { bytes, type -> jacksonObjectMapper().readValue(bytes, type.javaObjectType) }
 
-                        initialize {
-                            exchangeDeclare("exchange", "direct", true)
-                            queueDeclare("queue", true, false, false, emptyMap())
-                            queueBind("queue", "exchange", "routingKey")
+                            initialize {
+                                exchangeDeclare("exchange", "direct", true)
+                                queueDeclare("queue", true, false, false, emptyMap())
+                                queueBind("queue", "exchange", "routingKey")
+                            }
                         }
-                    })
+                )
             }
 
             rabbitConsumer {

--- a/src/test/kotlin/pl/jutupe/ktor_rabbitmq/ConsumerTest.kt
+++ b/src/test/kotlin/pl/jutupe/ktor_rabbitmq/ConsumerTest.kt
@@ -54,6 +54,46 @@ class ConsumerTest : IntegrationTest() {
     }
 
     @Test
+    fun `should consume message when published using precreated RabbitMQ`() {
+        val consumer = mockk<ConsumerScope.(TestObject) -> Unit>()
+
+        withTestApplication({
+            install(RabbitMQ) {
+                rabbitMQInstance = RabbitMQInstance(RabbitMQConfiguration.create()
+                    .apply {
+                        uri = "amqp://guest:guest@${rabbit.host}:${rabbit.amqpPort}"
+                        connectionName = "Connection name"
+
+                        serialize { jacksonObjectMapper().writeValueAsBytes(it) }
+                        deserialize { bytes, type -> jacksonObjectMapper().readValue(bytes, type.javaObjectType) }
+
+                        initialize {
+                            exchangeDeclare("exchange", "direct", true)
+                            queueDeclare("queue", true, false, false, emptyMap())
+                            queueBind("queue", "exchange", "routingKey")
+                        }
+                    })
+            }
+
+            rabbitConsumer {
+                consume("queue", true, rabbitDeliverCallback = consumer)
+            }
+        }) {
+            // given
+            val body = TestObject("value")
+            val convertedBody = jacksonObjectMapper().writeValueAsBytes(body)
+
+            // when
+            withChannel {
+                basicPublish("exchange", "routingKey", null, convertedBody)
+            }
+
+            // then
+            verify { consumer.invoke(any(), eq(body)) }
+        }
+    }
+
+    @Test
     fun `should log error when invalid body published`() {
         val consumer = mockk<ConsumerScope.(TestObject) -> Unit>()
         val logger = mockk<Logger>(relaxUnitFun = true)

--- a/src/test/kotlin/pl/jutupe/ktor_rabbitmq/InitializeTest.kt
+++ b/src/test/kotlin/pl/jutupe/ktor_rabbitmq/InitializeTest.kt
@@ -52,20 +52,22 @@ class InitializeTest : IntegrationTest() {
     fun `should support passing pre-initialized instance of RabbitMQ`(): Unit =
         withTestApplication({
             install(RabbitMQ) {
-                rabbitMQInstance = RabbitMQInstance(RabbitMQConfiguration.create()
-                    .apply {
-                        uri = "amqp://guest:guest@${rabbit.host}:${rabbit.amqpPort}"
-                        connectionName = "Connection name"
+                rabbitMQInstance = RabbitMQInstance(
+                    RabbitMQConfiguration.create()
+                        .apply {
+                            uri = "amqp://guest:guest@${rabbit.host}:${rabbit.amqpPort}"
+                            connectionName = "Connection name"
 
-                        serialize { jacksonObjectMapper().writeValueAsBytes(it) }
-                        deserialize { bytes, type -> jacksonObjectMapper().readValue(bytes, type.javaObjectType) }
+                            serialize { jacksonObjectMapper().writeValueAsBytes(it) }
+                            deserialize { bytes, type -> jacksonObjectMapper().readValue(bytes, type.javaObjectType) }
 
-                        initialize {
-                            exchangeDeclare("exchange", "direct", true)
-                            queueDeclare("queue", true, false, false, emptyMap())
-                            queueBind("queue", "exchange", "routingKey")
+                            initialize {
+                                exchangeDeclare("exchange", "direct", true)
+                                queueDeclare("queue", true, false, false, emptyMap())
+                                queueBind("queue", "exchange", "routingKey")
+                            }
                         }
-                    })
+                )
             }
         }) {
             // when


### PR DESCRIPTION
In case RabbitMQ plugin is used in combination with a dependency injection mechanism (e. g. Koin), there is a chicken-and-egg problem in case consumer or producer relies on any service only provided via DI.

1) If RabbitMQ plugin is installed before DI plugin is, then consumer may start processing messages already available in the broker early, and break down because dependency injection for the consumer will fail, as DI plugin was not yet configured;

2) If RabbitMQ plugin is installed after DI plugin is, it is not possible to inject an instance of RabbitMQ into services that depend on it (e. g. for publishing their output).

This PR makes it possible for DI plugin to instantiate RabbitMQ instance and make it available via DI injection context, and RabbitMQ plugin to reuse that previously instantiated RabbitMQ for plugin registration.